### PR TITLE
python: Fix missing argument from build_query_tree

### DIFF
--- a/src/python.rs
+++ b/src/python.rs
@@ -35,7 +35,7 @@ fn parse_query(q: &str) -> PyResult<QueryTreePy> {
     let tree = crate::parse(q, false);
     let mut c = tree.walk();
 
-    let qt = crate::builder::build_query_tree(q, &mut c, false);
+    let qt = crate::builder::build_query_tree(q, &mut c, false, None);
     Ok(QueryTreePy { qt })
 }
 


### PR DESCRIPTION
In 545bf4fcdc97f0d806533646a36c4f34afa4c1bd (#23), a fourth argument to `builder::build_query_tree` was introduced, but not added to the python bindings.

Building with `cargo build --features "python"` fails with:
```
error[E0061]: this function takes 4 arguments but 3 arguments were supplied
  --> src/python.rs:38:14
   |
38 |     let qt = crate::builder::build_query_tree(q, &mut c, false);
   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ -  ------  ----- supplied 3 arguments
   |              |
   |              expected 4 arguments
   |
note: function defined here
  --> src/builder.rs:28:8
   |
28 | pub fn build_query_tree(
   |        ^^^^^^^^^^^^^^^^
29 |     source: &str,
   |     ------------
30 |     cursor: &mut TreeCursor,
   |     -----------------------
31 |     is_cpp: bool,
   |     ------------
32 |     regex_constraints: Option<RegexMap>,
   |     -----------------------------------

For more information about this error, try `rustc --explain E0061`.
error: could not compile `weggli` due to previous error
```

This fixes the python build.