### PR TITLE
 Check if an invalid query is valid in C++ mode

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -83,6 +83,12 @@ fn main() {
                 }
                 Err(msg) => {
                     eprintln!("{}", msg);
+                    if !args.cpp
+                        && parse_search_pattern(pattern, true, args.force_query, &regex_constraints)
+                            .is_ok()
+                    {
+                        eprintln!("{} This query is valid in C++ mode (-X)", "Note:".bold());
+                    }
                     std::process::exit(1);
                 }
             }


### PR DESCRIPTION
If so notify the user to try again with -X instead of just
stating that parsing the query failed.

---

Example output:

```
$ weggli 'namespace { }' src/
Error! Query parsing failed: namespace { }
Note: This query is valid in C++ mode (-X)
```
