### PR TITLE
Hardcode rustc to 1.60.0 for Python CI 

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Install latest rust toolchain
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: stable
+          toolchain: 1.60
           default: true
           override: true
 

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -13,7 +13,6 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           toolchain: 1.60
-          default: true
           override: true
 
       - name: install python dependencies

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Install latest rust toolchain
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.60
+          toolchain: 1.60.0
           override: true
 
       - name: install python dependencies


### PR DESCRIPTION
rustc >=1.61.0 breaks the build of our Python API (see https://github.com/rust-lang/rust/blob/1.61.0/RELEASES.md#compatibility-notes).

Lets wait for https://github.com/rust-lang/cc-rs/pull/671 to land and hardcode the CI environment to 1.60.0 for now. 

