### PR TITLE
cli.rs: give --extensions example

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -331,7 +331,7 @@ strict:   Enable stricter matching. This turns off statement unwrapping and gree
  Input directory or file to search. By default, weggli will search inside 
  .c and .h files for the default C mode or .cc, .cpp, .cxx, .h and .hpp files when
  executing in C++ mode (using the --cpp option).
- Alternative file endings can be specified using the --extensions (-e) option.
+ Alternative file endings can be specified using the --extensions=h,c (-e) option.
  
  When combining weggli with other tools or preprocessing steps, 
  files can also be specified via STDIN by setting the directory to '-' 


### PR DESCRIPTION
The current CLI `--help` text does not state what is the format of the `--extensions` or `-e` flags, so this commit makes it more verbose by giving an explicit example within the help text.

This will help prevent users to get confused when they use Weggli like this:
```
$ weggli -e '.h' -X "..." <path>
No files to parse. Exiting...
$ weggli -e '*.h' -X "..." <path>
No files to parse. Exiting...
```